### PR TITLE
today's stuff for hipchat_handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 spec/fixtures/modules/
-
+/bin/

--- a/files/hipchat.rb
+++ b/files/hipchat.rb
@@ -1,0 +1,5 @@
+require "#{File.dirname(__FILE__)}/base"
+#require_relative 'base'
+
+class Hipchat < BaseHandler
+end

--- a/spec/functions/hipchat_spec.rb
+++ b/spec/functions/hipchat_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+# Intercept the hook that sensu uses to auto-execute checks by entirely replacing
+# the method used in Kernel before loading the handler.
+# This is _terrible_, see also https://github.com/sensu/sensu-plugin/pull/61
+module Kernel
+  def at_exit(&block)
+  end
+end
+
+require "#{File.dirname(__FILE__)}/../../files/hipchat"
+
+class Hipchat
+  attr_accessor :settings
+end
+
+describe Hipchat do
+  include SensuHandlerTestHelper
+
+  subject { described_class.new }
+  before(:each) { setup_event! }
+
+  # two silly tests just for starter
+  it { expect(subject).to be_a BaseHandler }
+  it { expect(subject).to be_a Sensu::Handler }
+end


### PR DESCRIPTION
drew this is my PR into opentable:hipchat_handler from my fork

currently opentable:hipchat_handler doesn't have anything on it.
and this PR doesn't have much but it does have what we got through
this morning.

111a115 (fess, 10 minutes ago)
   initial stub of hipchat handler

   spec_file and hipchat.rb does nothing yet.

c0c3de6 (fess, 8 hours ago)
   ignore binstubs
