### PR TITLE
Add Sensu Filters to exclude Timeouts from paging teams via PagerDuty

### DIFF
--- a/manifests/pagerduty.pp
+++ b/manifests/pagerduty.pp
@@ -17,6 +17,14 @@ class sensu_handlers::pagerduty (
   sensuclassic::filter { 'page_filter':
     attributes => { 'check' => { 'page' => true } },
   } ->
+  sensuclassic::filter { 'execution_timed_out_page_filter':
+    attributes => { 'check' => { 'output' => 'Execution timed out' } },
+    negate     => true,
+  } ->
+  sensuclassic::filter { 'unknown_no_metrics_received_page_filter':
+    attributes => { 'check' => { 'output' => "UNKNOWN: no metrics received from graphite\n" } },
+    negate     => true,
+  } ->
   sensuclassic::handler { 'pagerduty':
     type    => 'pipe',
     source  => 'puppet:///modules/sensu_handlers/pagerduty.rb',
@@ -25,6 +33,8 @@ class sensu_handlers::pagerduty (
     },
     filters => flatten([
       'page_filter',
+      'execution_timed_out_page_filter',
+      'unknown_no_metrics_received_page_filter',
       $sensu_handlers::num_occurrences_filter_for_pagerduty,
     ]),
   } ->

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -100,7 +100,7 @@ describe 'sensu_handlers', :type => :class do
         should contain_sensu__handler('jira') \
           .with_filters(['ticket_filter'])
         should contain_sensu__handler('pagerduty') \
-          .with_filters(['page_filter'])
+          .with_filters(['page_filter', 'execution_timed_out_page_filter', 'unknown_no_metrics_received_page_filter'])
         should contain_sensu__handler('nodebot').with_filters([])
         should contain_sensu__handler('mailer').with_filters([])
       }
@@ -113,7 +113,7 @@ describe 'sensu_handlers', :type => :class do
         should contain_sensu__handler('jira') \
           .with_filters(['ticket_filter', 'num_occurrences_filter'])
         should contain_sensu__handler('pagerduty') \
-          .with_filters(['page_filter', 'num_occurrences_filter_for_pagerduty'])
+          .with_filters(['page_filter', 'execution_timed_out_page_filter', 'unknown_no_metrics_received_page_filter', 'num_occurrences_filter_for_pagerduty'])
         should contain_sensu__handler('nodebot') \
           .with_filters(['num_occurrences_filter'])
         should contain_sensu__handler('mailer') \

--- a/spec/classes/pagerduty_spec.rb
+++ b/spec/classes/pagerduty_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+describe 'sensu_handlers::pagerduty' do
+  let(:facts) {{
+    :osfamily => 'Debian',
+    :lsbdistid => 'debian',
+  }}
+  let(:teams) {{
+    'operations' => {}
+  }}
+  let(:pre_condition) do
+    "class { 'sensu_handlers': teams => #{teams} }"
+  end
+  let(:hiera_data) {{
+    'sensu_handlers::teams' => teams,
+  }}
+
+  it { should compile }
+
+  it 'creates page_filter' do
+    should contain_sensu__filter('page_filter').with(
+      :attributes => { 'check' => { 'page' => true } }
+    )
+  end
+
+  it 'creates execution_timed_out_page_filter with negate' do
+    should contain_sensu__filter('execution_timed_out_page_filter').with(
+      :attributes => { 'check' => { 'output' => 'Execution timed out' } },
+      :negate     => true
+    )
+  end
+
+  it 'creates unknown_no_metrics_received_page_filter with negate' do
+    should contain_sensu__filter('unknown_no_metrics_received_page_filter').with(
+      :attributes => { 'check' => { 'output' => "UNKNOWN: no metrics received from graphite\n" } },
+      :negate     => true
+    )
+  end
+
+  it 'configures pagerduty handler with all filters' do
+    should contain_sensu__handler('pagerduty').with_filters(
+      ['page_filter', 'execution_timed_out_page_filter', 'unknown_no_metrics_received_page_filter']
+    )
+  end
+end


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add two new Sensu filters to PagerDuty handler configuration

- Filter out "Execution timed out" check failures from paging

- Filter out "UNKNOWN: no metrics received from graphite" failures

- Add comprehensive test coverage for new filters


___

### Diagram Walkthrough


```mermaid
flowchart LR
  PD["PagerDuty Handler"]
  PF["page_filter"]
  TF["execution_timed_out_page_filter"]
  MF["unknown_no_metrics_received_page_filter"]
  PD -- "applies filters" --> PF
  PD -- "applies filters" --> TF
  PD -- "applies filters" --> MF
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pagerduty.pp</strong><dd><code>Add timeout and metrics filters to PagerDuty</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

manifests/pagerduty.pp

<ul><li>Added <code>execution_timed_out_page_filter</code> to exclude checks with <br>"Execution timed out" output<br> <li> Added <code>unknown_no_metrics_received_page_filter</code> to exclude graphite <br>metric failures<br> <li> Both filters use negate flag to exclude matching events from paging<br> <li> Updated pagerduty handler to apply all three filters in sequence</ul>


</details>


  </td>
  <td><a href="https://github.com/opentable/sensu_handlers/pull/18/files#diff-ed71fd94dd0fecf931ed905d5887deb60eb7685f09bf839e44bbf322dd731684">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pagerduty_spec.rb</strong><dd><code>Add comprehensive PagerDuty filter tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

spec/classes/pagerduty_spec.rb

<ul><li>Created new test file for pagerduty class specifications<br> <li> Added tests for <code>page_filter</code> creation and configuration<br> <li> Added tests for <code>execution_timed_out_page_filter</code> with negate flag<br> <li> Added tests for <code>unknown_no_metrics_received_page_filter</code> with negate <br>flag<br> <li> Added test verifying pagerduty handler applies all filters</ul>


</details>


  </td>
  <td><a href="https://github.com/opentable/sensu_handlers/pull/18/files#diff-e638b04ed227e08fe1b407ee05b44662ec0b0d50347e83ef1528f07d6fd09744">+45/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>init_spec.rb</strong><dd><code>Update init specs for new PagerDuty filters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

spec/classes/init_spec.rb

<ul><li>Updated default context to expect three filters for pagerduty handler<br> <li> Updated num_occurrences_filter context to include new filters in <br>pagerduty configuration<br> <li> Tests now verify both new timeout-related filters are applied</ul>


</details>


  </td>
  <td><a href="https://github.com/opentable/sensu_handlers/pull/18/files#diff-3f04b2664372e51458e86767edf7f0541c0223fba756ea8ea933df845679914e">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

